### PR TITLE
Fix shape mismatch when train only with CPU

### DIFF
--- a/src/datasources/unityeyes.py
+++ b/src/datasources/unityeyes.py
@@ -296,6 +296,6 @@ class UnityEyes(BaseDataSource):
                 for landmark in entry['landmarks']
             ]).astype(np.float32)
             if self.data_format == 'NHWC':
-                np.transpose(entry['heatmaps'], (1, 2, 0))
+                entry['heatmaps'] = np.transpose(entry['heatmaps'], (1, 2, 0))
 
         return entry

--- a/src/models/elg.py
+++ b/src/models/elg.py
@@ -75,7 +75,10 @@ class ELG(BaseModel):
         with tf.variable_scope('hourglass'):
             # TODO: Find better way to specify no. landmarks
             if y1 is not None:
-                self._hg_num_landmarks = y1.shape.as_list()[1]
+                if self._data_format == 'NCHW':
+		    self._hg_num_landmarks = y1.shape.as_list()[1]
+                if self._data_format == 'NHWC':
+		    self._hg_num_landmarks = y1.shape.as_list()[3]
             else:
                 self._hg_num_landmarks = 18
             assert self._hg_num_landmarks == 18


### PR DESCRIPTION
When train in CPU mode with `data_format='NHWC'`, there are problems of shape mismatch of `entry['heatmaps']` because it is not transposed correctly.